### PR TITLE
Conversion, preparation for v25, raise error for duplicates

### DIFF
--- a/staging/conversion.xpl
+++ b/staging/conversion.xpl
@@ -94,11 +94,16 @@
     <p:choose>
         <!-- case: duplicates in 'current' -->
         <p:when test="*:current/*:orth">
-            <p:xslt>
+            <p:xslt name="duplicates">
                 <p:input port="stylesheet">
                     <p:document href="library/transformation/0-check-current-data-for-duplicates-md.xsl"/>
                 </p:input>
             </p:xslt>
+            <p:error name="error-duplicates" code="duplicates">
+                <p:input port="source">
+                    <p:pipe port="result" step="duplicates"/>
+                </p:input>
+            </p:error>
         </p:when>
         <!-- case: no duplicates in 'current' -->
         <p:otherwise>
@@ -117,14 +122,24 @@
         </p:otherwise>
     </p:choose>
     
+    <p:identity name="wrapped-transformation-result">
+        <p:input port="source"/>
+    </p:identity>
+    <p:store>
+        <p:with-option name="href" select="'debug/wrapped-transformation-result.xml'"/>
+        <p:with-option name="indent" select="'true'"/>
+    </p:store>
+    <p:identity>
+        <p:input port="source">
+            <p:pipe port="result" step="wrapped-transformation-result"/>
+        </p:input>
+    </p:identity>
+    
     <!-- generation of import reporting -->
     <p:documentation>
         <h2>Import reporting</h2>
         <p>This step generates a report in markdown format showing the proportion between previously existing and newly added entries.</p>
     </p:documentation>
-    <p:identity name="wrapped-transformation-result">
-        <p:input port="source"/>
-    </p:identity>
     <pwl:log>
         <p:with-param name="comparisonBase" select="$comparisonBase"/>
     </pwl:log>

--- a/staging/library/transformation/0-check-current-data-for-duplicates-md.xsl
+++ b/staging/library/transformation/0-check-current-data-for-duplicates-md.xsl
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" version="2.0">
     <xsl:template match="/">
+        <xsl:message>CAUTION: duplicates present in input.</xsl:message>
         <md-wrapper>
             <xsl:text>
 # WL Import Report </xsl:text><xsl:value-of select="format-date(current-date(), '[Y0001]-[M01]-[D01]')"/><xsl:text>


### PR DESCRIPTION
Before running the transformation, the `current` directory is checked for duplicates. Up to now the transformation was run despite the presence of duplicates. This led to problems further in the pipeline (Calabash err:XD0008) and was useless in general since the duplicate list was passed on to the pipeline instead of the transformation result.

To mitigate the problem the pipeline will now raise an error when duplicates are detected and the conversion is aborted (the error message contains a list/table of the duplicates).

In addition to that and to facilitate debugging, the transformation result is now stored at `staging/debug/wrapped-transformation-result.xml`.